### PR TITLE
Experimental mode added (An exception is thrown on non zero output)

### DIFF
--- a/example/curl.spy
+++ b/example/curl.spy
@@ -1,3 +1,4 @@
+#!/usr/bin/env shellpy
 """
 This script downloads avatar of github user 'python' with curl
 """

--- a/example/curl_x.spy
+++ b/example/curl_x.spy
@@ -1,0 +1,21 @@
+#!/usr/bin/env shellpy
+"""
+This script downloads avatar of github user 'python' with curl
+For shellpython EXPERIMENTAL mode
+"""
+
+import json
+import os
+import tempfile
+
+# get the api answer with curl
+answer = `curl https://api.github.com/users/python
+
+answer_json = json.loads(answer.stdout)
+avatar_url = answer_json['avatar_url']
+
+destination = os.path.join(tempfile.gettempdir(), 'python.png')
+
+# execute curl once again, this time to get the image
+result = `curl {avatar_url} > {destination}
+p`ls -l {destination}

--- a/example/git.spy
+++ b/example/git.spy
@@ -1,3 +1,4 @@
+#!/usr/bin/env shellpy
 """
 This script clones shellpython to temporary directory and finds the commit hash where README was created
 """

--- a/shellpython/config.py
+++ b/shellpython/config.py
@@ -2,6 +2,9 @@ import pickle
 import base64
 import sys
 
+# TODO: subject for further refactoring. Config should be serialized in nicer way. Now we cannot do it unless we break
+# compatibility
+
 # prints all commands being executed
 PRINT_ALL_COMMANDS = False
 
@@ -12,6 +15,7 @@ PRINT_STDOUT_ALWAYS = False
 PRINT_STDERR_ALWAYS = False
 
 # every error (returncode != 0) in executed commands will make the script stop
+# TODO: subject for further refactoring. It does not exit not, but throw an error
 EXIT_ON_ERROR = False
 
 # colorama is a plugin that makes output colored, this flag controls whether it is enabled

--- a/shellpython/header.tpl
+++ b/shellpython/header.tpl
@@ -1,4 +1,4 @@
 #shellpy-encoding
 #shellpy-meta:{meta}
-from shellpython.core import exe
+from shellpython.core import exe, NonZeroReturnCodeError
 

--- a/shellpython/header_root.tpl
+++ b/shellpython/header_root.tpl
@@ -6,7 +6,7 @@ import os
 import shellpython
 import shellpython.config
 from shellpython.constants import *
-from shellpython.core import exe, _print_stderr as shellpy_print_stderr
+from shellpython.core import exe, NonZeroReturnCodeError, _print_stderr as shellpy_print_stderr
 
 if __name__ == '__main__':
     shellpython.init()

--- a/shellpython/shellpy.py
+++ b/shellpython/shellpy.py
@@ -29,6 +29,13 @@ For arguments help use:
                         action="store_true")
     parser.add_argument('-vv', help='even bigger output verbosity. All stdout and stderr of executed commands is '
                                     'printed', action="store_true")
+    parser.add_argument('-t', '--throw-on-error', help='Throw NonZeroReturnCodeError on every non zero output of '
+                                                       'shell commands',
+                        action="store_true")
+    parser.add_argument('-x', '--experimental-mode', help='Runs shellpython in experimental mode. This is what could '
+                                                          'be a normal mode in the future. This mode now enables '
+                                                          'the throw-on-error flag', action="store_true")
+
     shellpy_args, unknown_args = parser.parse_known_args()
 
     if shellpy_args.verbose or shellpy_args.vv:
@@ -37,6 +44,9 @@ For arguments help use:
     if shellpy_args.vv:
         config.PRINT_STDOUT_ALWAYS = True
         config.PRINT_STDERR_ALWAYS = True
+
+    if shellpy_args.throw_on_error or shellpy_args.experimental_mode:
+        config.EXIT_ON_ERROR = True
 
     filename = shellpy_args.file
     filename_index = sys.argv.index(filename)

--- a/shellpython/tests/test_unix_core.py
+++ b/shellpython/tests/test_unix_core.py
@@ -1,7 +1,7 @@
 import unittest
-import os
+import mock
 
-from shellpython import core
+from shellpython import core, config
 
 
 class StreamMock:
@@ -73,3 +73,47 @@ class TestExecute(unittest.TestCase):
         core._create_result('cat non_existent_file', 'p')
 
         self.assertEqual(len(self.stdout_mock.lines), 0)
+
+    def test_exe(self):
+        result = core.exe('echo 1', '')
+
+        self.assertEqual(result.stdout, '1')
+        self.assertEqual(str(result), '1')
+        self.assertTrue(result == '1')
+        self.assertEqual(result.__bool__(), True)
+
+        self.assertEqual(len(self.stdout_mock.lines), 0)
+        self.assertEqual(len(self.stderr_mock.lines), 0)
+
+    def test_interactive(self):
+        result = core.exe('echo 1', 'i')
+
+        self.assertEqual(result.sreadline(), '1')
+        self.assertRaises(StopIteration, result.sreadline)
+
+        self.assertEqual(len(self.stdout_mock.lines), 0)
+        self.assertEqual(len(self.stderr_mock.lines), 0)
+
+    def test_interactive_param_p(self):
+        result = core.exe('echo 1', 'ip')
+
+        self.assertEqual(result.sreadline(), '1')
+        self.assertRaises(StopIteration, result.sreadline)
+
+        self.assertEqual(len(self.stdout_mock.lines), 1)
+        self.assertEqual(self.stdout_mock.lines[0], '1')
+
+        self.assertEqual(len(self.stderr_mock.lines), 0)
+
+    @mock.patch('shellpython.config.PRINT_ALL_COMMANDS', True)
+    @mock.patch('shellpython.config.COLORAMA_ENABLED', False)
+    def test_config_print_all(self):
+        core.exe('echo 1', '')
+
+        self.assertEqual(len(self.stdout_mock.lines), 1)
+        self.assertEqual(self.stdout_mock.lines[0], '>>> echo 1')
+
+    @mock.patch('shellpython.config.EXIT_ON_ERROR', True)
+    def test_throw_on_error_mode(self):
+        self.assertRaises(core.NonZeroReturnCodeError, core.exe, 'ls -l /non_existent_file', '')
+


### PR DESCRIPTION
In the experimental mode every non zero return code causes an
exception NonZeroReturnCodeError to be thrown. User in this mode
is supposed to handle errors not with IF but with EXCEPT.
Rationale for this is that most likely people do not handle errors
for all lines of shell code and there is not way to make them
handle it like in Go. Thus it is easy to skip an error in shell
and continue excecution with it not even noticing it without
verbose output turned on. The mode with exception solves this
problem well. It is a python way and makes you see all the errors.