### PR TITLE
[#69] Provides better support for python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ script:
   - python -m unittest discover
 
   - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then shellpy example/allinone/test.spy;  fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then shellpy example/allinone/test3.spy; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then shellpy3 example/allinone/test3.spy; fi
   - example/import_from_python/import.py

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,9 @@ try:
 
     args_for_setup = {'entry_points': {
         'console_scripts': {
-            'shellpy = shellpython.shellpy:main'
+            'shellpy = shellpython.shellpy:main2',
+            'shellpy2 = shellpython.shellpy:main2',
+            'shellpy3 = shellpython.shellpy:main3'
         }
     }}
 

--- a/shellpy
+++ b/shellpy
@@ -1,1 +1,4 @@
-shellpython/shellpy.py
+#!/usr/bin/env python
+from shellpython import shellpy
+
+shellpy.main2()

--- a/shellpy3
+++ b/shellpy3
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+from shellpython import shellpy
+
+shellpy.main3()

--- a/shellpython/header_root.tpl
+++ b/shellpython/header_root.tpl
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#shellpy-python-executable
 #shellpy-encoding
 #shellpy-meta:{meta}
 

--- a/shellpython/shellpy.py
+++ b/shellpython/shellpy.py
@@ -9,7 +9,15 @@ from argparse import ArgumentParser
 from shellpython.constants import *
 
 
-def main():
+def main2():
+    main(python_version=2)
+
+
+def main3():
+    main(python_version=3)
+
+
+def main(python_version):
     custom_usage = '''%(prog)s [SHELLPY ARGS] file [SCRIPT ARGS]
 
 For arguments help use:
@@ -45,7 +53,7 @@ For arguments help use:
     # comment out if want to keep them
     script_args = [x for x in unknown_args if x not in sys.argv[:filename_index]]
 
-    processed_file = preprocess_file(filename, is_root_script=True)
+    processed_file = preprocess_file(filename, is_root_script=True, python_version=python_version)
 
     # include directory of the script to pythonpath
     new_env = os.environ.copy()


### PR DESCRIPTION
shellpy, shellpy2, shellpy3 executables are installed on user systems
by analogy with PEP 394 -- The "python" Command on Unix-Like Systems