### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ and long lines
       a very long \
       line
 
-Every shellpy exression returns a Result
+Every shellpy expression returns a Result
 
     result = `ls -l
     

--- a/shellpython/core.py
+++ b/shellpython/core.py
@@ -138,7 +138,7 @@ class InteractiveResult:
     To get the result as string use str(Result)
     To get lines use the Result.lines field
     You can also iterate over lines of result like this: for line in Result:
-    You can compaire two results that will mean compaire of result strings
+    You can compare two results that will mean compare of result strings
     """
     def __init__(self, process, params):
         self._process = process
@@ -183,7 +183,7 @@ class Result:
     You can access underlying lines of result streams as Result.stdout_lines Result.stderr_lines.
     E.g. line_two = Result.stdout_lines[2]
 
-    You can also compaire two results that will mean compaire of result stdouts
+    You can also compare two results that will mean compare of result stdouts
     """
     def __init__(self):
         self._stdout_lines = []

--- a/shellpython/preprocessor.py
+++ b/shellpython/preprocessor.py
@@ -163,7 +163,7 @@ def _get_header(filepath, is_root_script, python_version):
 def _preprocess_code_to_intermediate(code):
     """Before compiling to actual python code all expressions are converted to universal intermediate form
     It is very convenient as it is possible to perform common operations for all expressions
-    The intemediate form looks like this:
+    The intermediate form looks like this:
     longline_shexe(echo 1)shexe(p)shexe
 
     :param code: code to convert to intermediate form


### PR DESCRIPTION
There are small typos in:
- README.md
- shellpython/core.py
- shellpython/preprocessor.py

Fixes:
- Should read `compare` rather than `compaire`.
- Should read `intermediate` rather than `intemediate`.
- Should read `expression` rather than `exression`.

Closes #74